### PR TITLE
Add condition to not ad default "size type" in "px" or "%" is present

### DIFF
--- a/lib/shortcode.php
+++ b/lib/shortcode.php
@@ -32,14 +32,6 @@ function anvato_shortcode($attr) {
 		'anvplayer'
 	);
 
-	// set "size type" from settings, if one is not already provided
-	if ( substr($json['height'], -1) !== '%' && substr($json['height'], -2) !== 'px' ) {
-		$json['height'] = $json['height'] . $player['height_type'];
-	}
-	if ( substr($json['width'], -1) !== '%' && substr($json['width'], -2) !== 'px' ) {
-		$json['width'] = $json['width'] . $player['width_type'];
-	}
-
 	$video_ids = explode( ",", $json["video"] );
 	if ( sizeof( $video_ids ) > 1 ) {
 		unset( $json["video"] );

--- a/lib/shortcode.php
+++ b/lib/shortcode.php
@@ -22,8 +22,8 @@ function anvato_shortcode($attr) {
 	$json = shortcode_atts(
 		array(
 			'mcp' => $mcp['mcp']['id'],
-			'width' => $player['width'],
-			'height' => $player['height'],
+			'width' => $player['width'] . $player['height_type'],
+			'height' => $player['height'] . $player['width_type'],
 			'video' => null,
 			'ext_id' => null,
 			'autoplay' => false
@@ -31,9 +31,14 @@ function anvato_shortcode($attr) {
 		$attr, 
 		'anvplayer'
 	);
-	
-	$json['height'] = $json['height'] . $player['height_type'];
-	$json['width'] = $json['width'] . $player['width_type'];
+
+	// set "size type" from settings, if one is not already provided
+	if ( substr($json['height'], -1) !== '%' && substr($json['height'], -2) !== 'px' ) {
+		$json['height'] = $json['height'] . $player['height_type'];
+	}
+	if ( substr($json['width'], -1) !== '%' && substr($json['width'], -2) !== 'px' ) {
+		$json['width'] = $json['width'] . $player['width_type'];
+	}
 
 	$video_ids = explode( ",", $json["video"] );
 	if ( sizeof( $video_ids ) > 1 ) {


### PR DESCRIPTION
For the Percent or Pixels, changed the situation to allow "custom sizing" and not forcing to pixels or percents, per Admin setting.
This way, if a custom-size player (ex: 300px by 100px) is necessary, the size will not be warped into percents (ex previously: 300px% by 100px%, currently: 300px by 100px)

The size-types is added if it is not present only, leaving the user to decide which size should be used.
