### PR TITLE
Remove VIP function vip_safe_wp_remote_get from Library

### DIFF
--- a/lib/class-anvato-library.php
+++ b/lib/class-anvato-library.php
@@ -247,11 +247,7 @@ class Anvato_Library {
 
 		$url = $this->build_request_url($params, time());
 		$args = array('body' => $this->xml_body, 'timeout' => 30);
-		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
-			$response = vip_safe_wp_remote_get( esc_url_raw( $url ), false, 3, 3, 20, $args );
-		} else {
-			$response = wp_remote_post( esc_url_raw( $url ), $args );
-		}
+		$response = wp_remote_post( esc_url_raw( $url ), $args );
 
 		if ( is_wp_error( $response ) ) {
 			return $response;


### PR DESCRIPTION
- Function vip_safe_wp_remote_get does not exist, so the piece of code never executes. The code is void.
