### PR TITLE
Change to add failsafes for bad Admin settings in Anvato plugin

### DIFF
--- a/mexp/template.php
+++ b/mexp/template.php
@@ -109,8 +109,6 @@ class MEXP_Anvato_Template extends MEXP_Template
 	 */
 	public function search($id, $tab) 
 	{   
-		usort($this->anv_settings['owners'], array($this, 'sortbylabel'));
-
 		$pref = array('type'=>'vod', 'station' => 0);
 		if( isset($_COOKIE['anv_user_preferences']) )
 		{
@@ -124,12 +122,16 @@ class MEXP_Anvato_Template extends MEXP_Template
 			>
 			<select name="station">
 				<option value=''>Select Station</option>
-				<?php foreach($this->anv_settings['owners'] as $key => $item)
-				{
-					echo "<option ".
-						($pref['station'] === $item['label'] ? 'selected' :'').
-						" value='{$item['id']}'>{$item['label']}</option>";
-				}
+				<?php
+					if ( !empty( $this->anv_settings ) && !empty( $this->anv_settings['owners'] ) ) {
+						usort( $this->anv_settings['owners'], array( $this, 'sortbylabel' ) );
+
+						foreach( $this->anv_settings['owners'] as $key => $item ) {
+							echo '<option value="' . esc_attr( $item['id'] ) . '" ' .
+								selected( $item['label'], $pref['station'], false ) .
+								'>' . esc_html( $item['label'] ) . '</option>';
+						}
+					} // if not-empty anv_serrings owners
 				?>
 			</select>
 			<select onchange="anv_type_select(this)" name='type'>


### PR DESCRIPTION
- Move sorting and processing of list under check and verification of list's existence
-- Prevents "Invalid argument supplied" and "expects parameter array" errors
- Escape outputs, per WP VIP guidelines

This is to fix the following warnings on WP VIP:
1. Warning: usort() expects parameter 1 to be array, null given in /mexp/template.php on line 112
2. Warning: Invalid argument supplied for foreach() in /mexp/template.php on line 127