### PR TITLE
Add "volume" to allowed parameters for anvplayer shortcode in WP

### DIFF
--- a/lib/shortcode.php
+++ b/lib/shortcode.php
@@ -29,6 +29,7 @@ function anvato_shortcode_get_parameters( $attr ) {
 			'ext_id' => null,
 			'sharelink' => null,
 			'autoplay' => false,
+			'volume' => 0.75,
 		),
 		$attr, 
 		'anvplayer'


### PR DESCRIPTION
- Per documentation "volume" is allowed parameter https://dev.anvato.net/api/player#embed-parameters
- Default "volume" is added as "0.75" value, not max 1